### PR TITLE
fix meta for windows

### DIFF
--- a/patch_apk.py
+++ b/patch_apk.py
@@ -172,7 +172,8 @@ def patch_apk(apk):
     apk_out = ZipFile(os.path.join(TEMP_FOLDER, "new_apk.apk"), "w")
     files = apk_in.infolist()
     for file in files:
-        if not os.path.exists(os.path.join(TEMP_FOLDER, file.filename)) and not file.filename.startswith("META-INF\\"):
+        # META-INF\\ is for linux, META-INF/ is for windows.
+        if not os.path.exists(os.path.join(TEMP_FOLDER, file.filename)) and not file.filename.startswith("META-INF\\") and not file.filename.startswith("META-INF/"):
             apk_out.writestr(file.filename, apk_in.read(file.filename), compress_type=file.compress_type, compresslevel=9)
     apk_in.close()
     libfolder = os.path.join(TEMP_FOLDER, "lib")


### PR DESCRIPTION
Hi Eltion,
`if not os.path.exists(os.path.join(TEMP_FOLDER, file.filename)) and not file.filename.startswith("META-INF\\"):`
I am assuming the line above will ignore folders having the word "META-INF", but it fails in Windows since the folder names in Windows does not contain characters "\\".
So I add another case for Windows is "META-INF/". The complete line will be as below:
`if not os.path.exists(os.path.join(TEMP_FOLDER, file.filename)) and not file.filename.startswith("META-INF\\") and not file.filename.startswith("META-INF/"):`
Thanks for your project.
Just a quick question. How do you know which file you need to patch like libsscronet or libbytehook?
Thanks again.